### PR TITLE
Expose interfaces for Inbox and Compose options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,26 @@
+export interface InboxOptions {
+  app?: string | null;
+  title?: string;
+  message?: string;
+  cancelLabel?: string;
+  removeText?: boolean;
+}
+
+export interface ComposeOptions extends InboxOptions {
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  body?: string;
+}
+
 export function openInbox({
   app,
   title,
   message,
   cancelLabel,
   removeText,
-}?: {
-  app?: string | null;
-  title?: string;
-  message?: string;
-  cancelLabel?: string;
-  removeText?: boolean;
-}): Promise<{ app: string; title: string } | null>;
+}?: InboxOptions): Promise<{ app: string; title: string } | null>;
 
 export function openComposer({
   app,
@@ -23,18 +33,7 @@ export function openComposer({
   bcc,
   subject,
   body,
-}?: {
-  app?: string | null;
-  title?: string;
-  message?: string;
-  cancelLabel?: string;
-  removeText?: boolean;
-  to?: string;
-  cc?: string;
-  bcc?: string;
-  subject?: string;
-  body?: string;
-}): Promise<{ app: string; title: string } | null>;
+}?: ComposeOptions): Promise<{ app: string; title: string } | null>;
 
 export class EmailException {
   message: string;


### PR DESCRIPTION
I felt that the options for `openInbox` and `openComposer` needed to be exposed.

This PR adds two interfaces. `InboxOptions` and `ComposeOptions`