### PR TITLE
Add title override for Apple Mail

### DIFF
--- a/src/ios.js
+++ b/src/ios.js
@@ -178,7 +178,8 @@ export function askAppChoice(
   title = "Open mail app",
   message = "Which app would you like to open?",
   cancelLabel = "Cancel",
-  removeText = false
+  removeText = false,
+  actionType = "open"
 ) {
   return new Promise(async (resolve, reject) => {
     let availableApps = [];
@@ -196,7 +197,11 @@ export function askAppChoice(
       return resolve(availableApps[0]);
     }
 
-    let options = availableApps.map((app) => titles[app]);
+    let options = availableApps.map((app) =>
+      actionType === "compose" && app === "apple-mail"
+        ? "default mail client"
+        : titles[app]
+    );
     options.push(cancelLabel);
 
     ActionSheetIOS.showActionSheetWithOptions(
@@ -220,9 +225,10 @@ export function askAppChoice(
  * @param {{
  *     app: string | undefined | null,
  * }} options
+ * @param {("open" | "compose")} actionType
  * @return string
  */
-async function getApp(options) {
+async function getApp(options, actionType) {
   if (options && typeof options !== "object") {
     throw new EmailException("First parameter must be an object of options.");
   }
@@ -243,7 +249,13 @@ async function getApp(options) {
 
   if (!app) {
     const { title, message, cancelLabel, removeText } = options;
-    app = await askAppChoice(title, message, cancelLabel, removeText);
+    app = await askAppChoice(
+      title,
+      message,
+      cancelLabel,
+      removeText,
+      actionType
+    );
   }
 
   return app;
@@ -261,7 +273,7 @@ async function getApp(options) {
  * }} options
  */
 export async function openInbox(options = {}) {
-  const app = await getApp(options);
+  const app = await getApp(options, "open");
 
   if (!app) {
     return null;
@@ -289,7 +301,7 @@ export async function openInbox(options = {}) {
  * }} options
  */
 export async function openComposer(options) {
-  const app = await getApp(options);
+  const app = await getApp(options, "compose");
 
   if (!app) {
     return null;

--- a/src/ios.js
+++ b/src/ios.js
@@ -199,7 +199,7 @@ export function askAppChoice(
 
     let options = availableApps.map((app) =>
       actionType === "compose" && app === "apple-mail"
-        ? "default mail client"
+        ? "Default email reader"
         : titles[app]
     );
     options.push(cancelLabel);


### PR DESCRIPTION
Since iOS 14 (and iPadOS 14) Apple allows users to change the default mail app

Because `mailto://` is used for composing (due to `message://` not supporting any parameters) the title no longer fits the app it opens. This proposal provides a bandaid in the form of an override based on the action type ("default mail client" instead of "Mail" when calling `openComposer`).