### PR TITLE
Add mailto scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Just add this in your `Info.plist` depending on which apps you'd like to support
 ```xml
 <key>LSApplicationQueriesSchemes</key>
 <array>
+    <string>mailto</string>
     <string>message</string>
     <string>readdle-spark</string>
     <string>airmail</string>

--- a/plugin/withEmailLink.js
+++ b/plugin/withEmailLink.js
@@ -27,6 +27,7 @@ const withLSApplicationQueriesSchemes = (config, schemes) => {
  */
 const withEmailLink = (config) => {
   config = withLSApplicationQueriesSchemes(config, [
+    "mailto",
     "message",
     "readdle-spark",
     "airmail",


### PR DESCRIPTION
iOS now seems to require adding the `mailto` scheme to `LSApplicationQueriesSchemes`. Adding it in the README and Expo plugin.

Resolves https://github.com/includable/react-native-email-link/issues/118