### PR TITLE
Support cc and bcc on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ openComposer();
 - [`removeText`](#removeText)
 - [`defaultEmailLabel`](#defaultEmailLabel)
 - [`to`](#to)
-- [`cc`](#cc) (iOS only)
-- [`bcc`](#bcc) (iOS only)
+- [`cc`](#cc)
+- [`bcc`](#bcc)
 - [`subject`](#subject)
 - [`body`](#body)
 - [`encodeBody`](#encodeBody)
@@ -236,7 +236,7 @@ Recipient's email address.
 
 #### `cc`
 
-Email's cc (iOS only).
+Email's cc.
 
 | Type   | Required | Default |
 | ------ | -------- | ------- |
@@ -244,7 +244,7 @@ Email's cc (iOS only).
 
 #### `bcc`
 
-Email's bcc (iOS only).
+Email's bcc.
 
 | Type   | Required | Default |
 | ------ | -------- | ------- |

--- a/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
@@ -74,17 +74,17 @@ public class EmailModule extends ReactContextBaseJavaModule {
         String uriText = "mailto:" + Uri.encode(to) +
                 "?subject=" + Uri.encode(subject) +
                 "&body=" + Uri.encode(body);
+        if(cc != null) {
+            uriText += "&cc=" + cc;
+        }
+        if(bcc != null) {
+            uriText += "&bcc=" + bcc;
+        }
         Uri uri = Uri.parse(uriText);
 
         send.setData(uri);
         Intent chooserIntent = Intent.createChooser(send, title);
         chooserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if(cc != null) {
-            chooserIntent.putExtra(Intent.EXTRA_CC, cc.split(","));
-        }
-        if(bcc != null) {
-            chooserIntent.putExtra(Intent.EXTRA_BCC, bcc.split(","));
-        }
         getReactApplicationContext().startActivity(chooserIntent);
     }
 

--- a/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
@@ -75,10 +75,10 @@ public class EmailModule extends ReactContextBaseJavaModule {
                 "?subject=" + Uri.encode(subject) +
                 "&body=" + Uri.encode(body);
         if(cc != null) {
-            uriText += "&cc=" + cc;
+            uriText += "&cc=" + Uri.encode(cc);
         }
         if(bcc != null) {
-            uriText += "&bcc=" + bcc;
+            uriText += "&bcc=" + Uri.encode(bcc);
         }
         Uri uri = Uri.parse(uriText);
 

--- a/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
@@ -69,7 +69,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void compose(final String title, final String to, final String subject, final String body) {
+    public void compose(final String title, final String to, final String subject, final String body, final String cc, final String bcc) {
         Intent send = new Intent(Intent.ACTION_SENDTO);
         String uriText = "mailto:" + Uri.encode(to) +
                 "?subject=" + Uri.encode(subject) +
@@ -79,6 +79,12 @@ public class EmailModule extends ReactContextBaseJavaModule {
         send.setData(uri);
         Intent chooserIntent = Intent.createChooser(send, title);
         chooserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        if(cc != null) {
+            chooserIntent.putExtra(Intent.EXTRA_CC, cc.split(","));
+        }
+        if(bcc != null) {
+            chooserIntent.putExtra(Intent.EXTRA_BCC, bcc.split(","));
+        }
         getReactApplicationContext().startActivity(chooserIntent);
     }
 

--- a/src/android.js
+++ b/src/android.js
@@ -44,6 +44,8 @@ export async function openInbox(options = {}) {
  *     title: string,
  *     removeText: boolean,
  *     to: string,
+ *     cc: string,
+ *     bcc: string,
  *     subject: string,
  *     body: string,
  *     encodeBody: boolean
@@ -64,6 +66,8 @@ export async function openComposer(options = {}) {
     text,
     options.to,
     options.subject || "",
-    body
+    body,
+    options.cc,
+    options.bcc
   );
 }


### PR DESCRIPTION
This pull request adds support for `bcc` and `cc` values to be placed in the `mailto` link on Android. It has been tested w/ the Gmail app on an Android emulator. Documentation updated to reflect that `cc` and `bcc` now available on Android or iOS.