### PR TITLE
Support RN new arch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,14 @@ buildscript {
     }
 }
 
+def isNewArchitectureEnabled() {
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
 apply plugin: 'com.android.library'
+if (isNewArchitectureEnabled()) {
+    apply plugin: 'com.facebook.react'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -46,11 +53,22 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode computeVersionCode()
         versionName computeVersionName()
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
 
     lintOptions {
         abortOnError false
         disable 'InvalidPackage'
+    }
+
+    sourceSets {
+        main {
+            if (isNewArchitectureEnabled()) {
+                java.srcDirs += ['src/newarch']
+            } else {
+                java.srcDirs += ['src/oldarch']
+            }
+        }
     }
 }
 

--- a/android/src/main/java/agency/flexible/react/modules/email/EmailPackage.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailPackage.java
@@ -1,33 +1,45 @@
 package agency.flexible.react.modules.email;
 
-import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.module.model.ReactModuleInfo;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.TurboReactPackage;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class EmailPackage implements ReactPackage {
+public class EmailPackage extends TurboReactPackage {
 
-  @Override
-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Collections.emptyList();
-  }
+    @Nullable
+    @Override
+    public NativeModule getModule(String name, ReactApplicationContext reactContext) {
+        if (name.equals(EmailImpl.NAME)) {
+            return new Email(reactContext);
+        } else {
+            return null;
+        }
+    }
 
-  @Override
-  public List<NativeModule> createNativeModules(
-                              ReactApplicationContext reactContext) {
-    List<NativeModule> modules = new ArrayList<>();
-
-    modules.add(new EmailModule(reactContext));
-
-    return modules;
-  }
-
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
+    @Override
+    public ReactModuleInfoProvider getReactModuleInfoProvider() {
+        return () -> {
+            final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+            boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+            moduleInfos.put(
+                EmailImpl.NAME,
+                new ReactModuleInfo(
+                    EmailImpl.NAME,
+                    EmailImpl.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    true, // hasConstants
+                    false, // isCxxModule
+                    isTurboModule // isTurboModule
+            ));
+            return moduleInfos;
+        };
+    }
 }

--- a/android/src/newarch/java/agency/flexible/react/modules/email/Email.java
+++ b/android/src/newarch/java/agency/flexible/react/modules/email/Email.java
@@ -1,0 +1,38 @@
+package agency.flexible.react.modules.email;
+
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.Promise;
+
+import java.util.Map;
+
+import agency.flexible.react.modules.email.NativeEmailSpec;
+
+public class Email extends NativeEmailSpec {
+
+    private final EmailImpl delegate;
+
+    public Email(ReactApplicationContext reactContext) {
+        super(reactContext);
+        delegate = new EmailImpl(reactContext);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return EmailImpl.NAME;
+    }
+
+    @Override
+    public void open(String title, boolean newTask, Promise promise) {
+        delegate.open(title,newTask,promise);
+    }
+
+    @Override
+    public void compose(String title, String to, String subject, String body, String cc, String bcc) {
+        delegate.compose(title,to,subject,body,cc,bcc);
+    }
+}

--- a/android/src/oldarch/java/agency/flexible/react/modules/email/Email.java
+++ b/android/src/oldarch/java/agency/flexible/react/modules/email/Email.java
@@ -1,0 +1,35 @@
+package agency.flexible.react.modules.email;
+
+import android.os.Build;
+
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+
+import java.util.Map;
+
+public class Email extends ReactContextBaseJavaModule {
+
+    private final EmailImpl delegate;
+
+    public Email(ReactApplicationContext reactContext) {
+        super(reactContext);
+        delegate = new EmailImpl(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return EmailImpl.NAME;
+    }
+
+    @ReactMethod
+    public void open(String title, boolean newTask, Promise promise) {
+        delegate.open(title,newTask,promise);
+    }
+
+    @ReactMethod
+    public void compose(String title, String to, String subject, String body, String cc, String bcc) {
+        delegate.compose(title,to,subject,body,cc,bcc);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,13 @@
   },
   "devDependencies": {
     "prettier": "^2.2.1"
+  },
+  "codegenConfig": {
+    "name": "EmailSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "agency.flexible.react.modules.email"
+    }
   }
 }

--- a/src/NativeEmail.js
+++ b/src/NativeEmail.js
@@ -1,0 +1,10 @@
+// @flow
+import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
+import { TurboModuleRegistry } from "react-native";
+
+export interface Spec extends TurboModule {
+  open: (title: string, newTask: boolean) => Promise<boolean>;
+  compose: (title: string, to: string, subject: string, body: string, cc: string, bcc: string) => void;
+}
+
+export default (TurboModuleRegistry.get<Spec>("Email"): ?Spec);

--- a/src/android.js
+++ b/src/android.js
@@ -1,5 +1,5 @@
-import { NativeModules } from "react-native";
 import { EmailException } from "./email-exception";
+import NativeEmail from './NativeEmail';
 
 /**
  * Open an email app, or let the user choose what app to open.
@@ -12,13 +12,6 @@ import { EmailException } from "./email-exception";
  * }} options
  */
 export async function openInbox(options = {}) {
-  // We can't pre-choose, since we use native intents
-  if (!("Email" in NativeModules)) {
-    throw new EmailException(
-      "NativeModules.Email does not exist. Check if you installed the Android dependencies correctly."
-    );
-  }
-
   let text = options.removeText
     ? ""
     : options.title || "What app would you like to open?";
@@ -29,7 +22,7 @@ export async function openInbox(options = {}) {
   }
 
   try {
-    await NativeModules.Email.open(text, newTask);
+    await NativeEmail.open(text, newTask);
   } catch (error) {
     if (error.code === "NoEmailAppsAvailable") {
       throw new EmailException("No email apps available");
@@ -62,7 +55,7 @@ export async function openComposer(options = {}) {
     body = encodeURIComponent(body);
   }
 
-  return NativeModules.Email.compose(
+  return NativeEmail.compose(
     text,
     options.to,
     options.subject || "",


### PR DESCRIPTION
## This PR adds support for both new and old architecture.

This change is Android only, since only Android requires native dev for opening mail through an intent.

## Suggestions / Discussions

- [ ] Make naming clearer (ex: `EmailPackage` -> `RNEmailPackage`, `EmailImpl` -> `RNEmailImpl`, `Email.java` -> `RNEmail.java`)

## ⚠️ This change needs to be tested on several versions of RN with both architecture to ensure retrocompatibility.

- I've tested it on RN 0.72.4 with both old and new arch.