### PR TITLE
feat(android): add namespace to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace 'agency.flexible.react.modules.email'
+    }
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {


### PR DESCRIPTION
Trivial change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions). 

I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above. 
