### PR TITLE
feat: enable buildFeatures.buildConfig for android gradle plugin 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,9 @@ android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
       namespace 'agency.flexible.react.modules.email'
+      buildFeatures {
+         buildConfig true
+      }
     }
     compileSdkVersion rootProject.ext.compileSdkVersion
 


### PR DESCRIPTION
Add support for RN 0.73.
Similar to https://github.com/th3rdwave/react-native-safe-area-context/pull/455