### PR TITLE
feat: `getEmailClients` method + `openComposer` accepting pre-selected `app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ console.log(clients)
 ]
 ```
 
-If you want to use this method to present, say, an email clients picker within a custom UI and then use the `openComposer` to open a certain app, simply pass `id` value in the options (`options.app`) in the `openComposer`.
+To utilize this feature to display an email client picker within a custom UI and subsequently use the `openComposer` to launch a specific app, you just need to pass the `id` (from response) value into the options (`options.app`) within the `openComposer`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ App to open the composer with
 
 | Type   | Required | Example         |
 | ------ | -------- | --------------- |
-| string | No       | Android - package name, e.g. `com.mail.app` |
-|        |          | iOS - app slug, e.g. `gmail` |
+| string | No       | An app's `id` that can be retrieved with `getEmailClients` |
+|        |          | On Android - `id` holds the package name, e.g. `com.mail.app` |
+|        |          | On iOS - `id` holds the app slug/name, e.g. `gmail` |
 
 #### `title`
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ openComposer();
 
 #### `app`
 
-App to open the composer in
+App to open the composer with
 
 | Type   | Required | Example         |
 | ------ | -------- | --------------- |

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ console.log(clients)
 ]
 ```
 
-> If you want to use this method to present, say, clients picker within a custom UI and then use the `openComposer`, simply pass `id` value in the options (`options.app`)
+If you want to use this method to present, say, an email clients picker within a custom UI and then use the `openComposer` to open a certain app, simply pass `id` value in the options (`options.app`) in the `openComposer`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ console.log(clients)
     iOSAppName: 'gmail', // iOS only
     prefix: 'gmail://',
     title: 'GMail',
-    androidPackagename: 'com.google.android.gm' // Android only
+    androidPackagename: 'com.google.android.gm', // Android only
     id: 'gmail' // depending on the platform, holds either the package name or the app slug value
   }
 ]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ openComposer();
 
 #### Arguments
 
+- [`app`](#app)
 - [`title`](#title)
 - [`message`](#message) (iOS only)
 - [`cancelLabel`](#cancelLabel) (iOS only)
@@ -185,6 +186,15 @@ openComposer();
 - [`subject`](#subject)
 - [`body`](#body)
 - [`encodeBody`](#encodeBody)
+
+#### `app`
+
+App to open the composer in
+
+| Type   | Required | Example         |
+| ------ | -------- | --------------- |
+| string | No       | Android - package name, e.g. `com.mail.app` |
+|        |          | iOS - app slug, e.g. `gmail` |
 
 #### `title`
 
@@ -286,6 +296,23 @@ openComposer({
 });
 ```
 
+### getEmailClients
+
+```javascript
+import { getEmailClients } from "react-native-email-link";
+
+const clients = await getEmailClients();
+
+console.log(clients)
+[
+  {
+    app: 'gmail', // iOS only
+    prefix: 'gmail://',
+    title: 'GMail',
+    packageName: '' // Android only
+  }
+]
+```
 ---
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -304,15 +304,20 @@ import { getEmailClients } from "react-native-email-link";
 const clients = await getEmailClients();
 
 console.log(clients)
+
 [
   {
-    app: 'gmail', // iOS only
+    iOSAppName: 'gmail', // iOS only
     prefix: 'gmail://',
     title: 'GMail',
-    packageName: '' // Android only
+    androidPackagename: 'com.google.android.gm' // Android only
+    id: 'gmail' // depending on the platform, holds either the package name or the app slug value
   }
 ]
 ```
+
+> If you want to use this method to present, say, clients picker within a custom UI and then use the `openComposer`, simply pass `id` value in the options (`options.app`)
+
 ---
 
 <div align="center">

--- a/index.android.js
+++ b/index.android.js
@@ -4,7 +4,7 @@
  * This file supports both iOS and Android.
  */
 
-import { openInbox, openComposer } from "./src/android";
+import { openInbox, openComposer, getEmailClients } from "./src/android";
 import { EmailException } from "./src/email-exception";
 
-export { EmailException, openInbox, openComposer };
+export { EmailException, openInbox, openComposer, getEmailClients };

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,8 @@ export interface ComposeOptions extends InboxOptions {
   body?: string;
 }
 
+export function getEmailClients(): Promise<string[]>;
+
 export function openInbox({
   app,
   title,

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,14 @@ export interface ComposeOptions extends InboxOptions {
   body?: string;
 }
 
-export function getEmailClients(): Promise<string[]>;
+export function getEmailClients(): Promise<
+  {
+    packageName: string;
+    title: string;
+    prefix: string;
+    app: string;
+  }[]
+>;
 
 export function openInbox({
   app,

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,10 +17,11 @@ export interface ComposeOptions extends InboxOptions {
 
 export function getEmailClients(): Promise<
   {
-    packageName: string;
+    androidPackageName: string;
     title: string;
     prefix: string;
-    app: string;
+    iOSAppName: string;
+    id: string;
   }[]
 >;
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,7 +4,7 @@
  * This file supports both iOS and Android.
  */
 
-import { openInbox, openComposer } from "./src/ios";
+import { openInbox, openComposer, getEmailClients } from "./src/ios";
 import { EmailException } from "./src/email-exception";
 
-export { EmailException, openInbox, openComposer };
+export { EmailException, openInbox, openComposer, getEmailClients };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // Placeholder file so that Expo plugin module resolution works
 
-import { openInbox, openComposer } from "./src/ios";
+import { openInbox, openComposer, getEmailClients } from "./src/ios";
 import { EmailException } from "./src/email-exception";
 
-export { EmailException, openInbox, openComposer };
+export { EmailException, openInbox, openComposer, getEmailClients };

--- a/src/android.js
+++ b/src/android.js
@@ -2,6 +2,28 @@ import { NativeModules } from "react-native";
 import { EmailException } from "./email-exception";
 
 /**
+ * Get available email clients
+ * iOS -> returns a list of app names, e.g. ['apple-mail', 'gmail', 'outlook']
+ * Android -> returns a list of app package names, e.g. ['com.google.android.gm', 'com.microsoft.office.outlook']
+ * @returns {Promise<string[]>}
+ */
+export async function getEmailClients() {
+  if (!("Email" in NativeModules)) {
+    throw new EmailException(
+      "NativeModules.Email does not exist. Check if you installed the Android dependencies correctly."
+    );
+  }
+
+  try {
+    return NativeModules.Email.getEmailClients();
+  } catch (error) {
+    if (error.code === "NoEmailAppsAvailable") {
+      throw new EmailException("No email apps available");
+    }
+  }
+}
+
+/**
  * Open an email app, or let the user choose what app to open.
  *
  * @param {{
@@ -39,6 +61,8 @@ export async function openInbox(options = {}) {
 
 /**
  * Open an email app on the compose screen, or let the user choose what app to open on the compose screen.
+ * Android - app should be a package name, e.g. 'com.google.android.gm' (use getEmailClients() to get a list of available clients)
+ * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients)
  *
  * @param {{
  *     title: string,
@@ -60,6 +84,18 @@ export async function openComposer(options = {}) {
 
   if (options.encodeBody) {
     body = encodeURIComponent(body);
+  }
+
+  if (options.app) {
+    return NativeModules.Email.composeWith(
+      options.app,
+      text,
+      options.to,
+      options.subject || "",
+      body,
+      options.cc,
+      options.bcc
+    );
   }
 
   return NativeModules.Email.compose(

--- a/src/android.js
+++ b/src/android.js
@@ -18,10 +18,11 @@ const titles = {
  * Get available email clients
  *
  * @returns {Promise<{
- *   packageName: string;
+ *   androidPackageName: string;
  *   title: string;
  *   prefix: string;
- *   app: string;
+ *   iOSAppName: string;
+ *   id: string;
  * }[]>}
  */
 export async function getEmailClients() {
@@ -39,10 +40,11 @@ export async function getEmailClients() {
 
       if (title) {
         acc.push({
-          packageName, // Android only
+          androidPackageName: packageName, // Android only
           title,
           prefix: "", // iOS only
-          app: "", // iOS only
+          iOSAppName: "", // iOS only
+          id: packageName,
         });
 
         return acc;

--- a/src/android.js
+++ b/src/android.js
@@ -16,9 +16,13 @@ const titles = {
 
 /**
  * Get available email clients
- * iOS -> returns a list of app names, e.g. ['apple-mail', 'gmail', 'outlook']
- * Android -> returns a list of app package names, e.g. ['com.google.android.gm', 'com.microsoft.office.outlook']
- * @returns {Promise<{}[]>}
+ *
+ * @returns {Promise<{
+ *   packageName: string;
+ *   title: string;
+ *   prefix: string;
+ *   app: string;
+ * }[]>}
  */
 export async function getEmailClients() {
   if (!("Email" in NativeModules)) {

--- a/src/android.js
+++ b/src/android.js
@@ -97,10 +97,10 @@ export async function openInbox(options = {}) {
 
 /**
  * Open an email app on the compose screen, or let the user choose what app to open on the compose screen.
- * Android - app should be a package name, e.g. 'com.google.android.gm' (use getEmailClients() to get a list of available clients)
- * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients - `app`)
+ * You can pass `id` to open a specific app, or `null` to let the user choose. (`id` can be retrieved with `getEmailClients`
  *
  * @param {{
+ *     app: string | undefined | null,
  *     title: string,
  *     removeText: boolean,
  *     to: string,

--- a/src/ios.js
+++ b/src/ios.js
@@ -276,6 +276,30 @@ async function getApp(options, actionType) {
 }
 
 /**
+ * Get available email clients
+ * iOS -> returns a list of app names, e.g. ['apple-mail', 'gmail', 'outlook']
+ * Android -> returns a list of app package names, e.g. ['com.google.android.gm', 'com.microsoft.office.outlook']
+ * @returns {Promise<string[]>}
+ */
+export function getEmailClients() {
+  return new Promise(async (resolve, reject) => {
+    let availableApps = [];
+    for (let app in prefixes) {
+      let avail = await isAppInstalled(app);
+      if (avail) {
+        availableApps.push(app);
+      }
+    }
+
+    if (availableApps.length === 0) {
+      return reject(new EmailException("No email apps available"));
+    }
+
+    return resolve(availableApps);
+  });
+}
+
+/**
  * Open an email app, or let the user choose what app to open.
  *
  * @param {{
@@ -300,6 +324,8 @@ export async function openInbox(options = {}) {
 
 /**
  * Open an email app on the compose screen, or let the user choose what app to open on the compose screen.
+ * Android - app should be a package name, e.g. 'com.google.android.gm' (use getEmailClients() to get a list of available clients)
+ * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients)
  *
  * @param {{
  *     app: string | undefined | null,

--- a/src/ios.js
+++ b/src/ios.js
@@ -277,9 +277,13 @@ async function getApp(options, actionType) {
 
 /**
  * Get available email clients
- * iOS -> returns a list of app names, e.g. ['apple-mail', 'gmail', 'outlook']
- * Android -> returns a list of app package names, e.g. ['com.google.android.gm', 'com.microsoft.office.outlook']
- * @returns {Promise<{}[]>}
+ *
+ * @returns {Promise<{
+ *   packageName: string;
+ *   title: string;
+ *   prefix: string;
+ *   app: string;
+ * }[]>}
  */
 export function getEmailClients() {
   return new Promise(async (resolve, reject) => {

--- a/src/ios.js
+++ b/src/ios.js
@@ -279,10 +279,11 @@ async function getApp(options, actionType) {
  * Get available email clients
  *
  * @returns {Promise<{
- *   packageName: string;
+ *   androidPackageName: string;
  *   title: string;
  *   prefix: string;
- *   app: string;
+ *   iOSAppName: string;
+ *   id: string;
  * }[]>}
  */
 export function getEmailClients() {
@@ -304,10 +305,11 @@ export function getEmailClients() {
 
       if (title) {
         acc.push({
-          packageName: "", // Android only
+          androidPackageName: "", // Android only
           title,
           prefix: prefixes[app], // iOS only
-          app, // iOS only
+          iOSAppName: app, // iOS only
+          id: app,
         });
 
         return acc;

--- a/src/ios.js
+++ b/src/ios.js
@@ -279,7 +279,7 @@ async function getApp(options, actionType) {
  * Get available email clients
  * iOS -> returns a list of app names, e.g. ['apple-mail', 'gmail', 'outlook']
  * Android -> returns a list of app package names, e.g. ['com.google.android.gm', 'com.microsoft.office.outlook']
- * @returns {Promise<string[]>}
+ * @returns {Promise<{}[]>}
  */
 export function getEmailClients() {
   return new Promise(async (resolve, reject) => {
@@ -295,7 +295,24 @@ export function getEmailClients() {
       return reject(new EmailException("No email apps available"));
     }
 
-    return resolve(availableApps);
+    const apps = availableApps.reduce((acc, app) => {
+      const title = titles[app] || "";
+
+      if (title) {
+        acc.push({
+          packageName: "", // Android only
+          title,
+          prefix: prefixes[app], // iOS only
+          app, // iOS only
+        });
+
+        return acc;
+      }
+
+      return acc;
+    }, []);
+
+    return resolve(apps);
   });
 }
 
@@ -325,7 +342,7 @@ export async function openInbox(options = {}) {
 /**
  * Open an email app on the compose screen, or let the user choose what app to open on the compose screen.
  * Android - app should be a package name, e.g. 'com.google.android.gm' (use getEmailClients() to get a list of available clients)
- * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients)
+ * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients - `app`)
  *
  * @param {{
  *     app: string | undefined | null,

--- a/src/ios.js
+++ b/src/ios.js
@@ -347,8 +347,7 @@ export async function openInbox(options = {}) {
 
 /**
  * Open an email app on the compose screen, or let the user choose what app to open on the compose screen.
- * Android - app should be a package name, e.g. 'com.google.android.gm' (use getEmailClients() to get a list of available clients)
- * iOS - app should be an app name, e.g. 'gmail' (use getEmailClients() to get a list of available clients - `app`)
+ * You can pass `id` to open a specific app, or `null` to let the user choose. (`id` can be retrieved with `getEmailClients`
  *
  * @param {{
  *     app: string | undefined | null,


### PR DESCRIPTION
# What this PR does?
- [ ] `openComposer` accepting an optional app that the composer should opened with (`packageName` or `slug`, depending on the platform)
- [ ] adds new `getEmailClients` method to fetch all available email apps installed on user's device (given the library supports these apps) - useful for displaying email clients list within custom UI

Thanks for the library!

I recently needed to develop a feature with a list of all available email apps on given device. Your library helped a lot, thanks for that!

BUT! the list needed to be put within some custom UI thus I needed to extend the API and decided to create a PR with my changes, maybe it could be useful for others!

Let me know what you think and if it is a good addition to the library / if anythings needs some tweaking

Have a good day, cheers!